### PR TITLE
update integration.json urls

### DIFF
--- a/integration.json
+++ b/integration.json
@@ -1,5 +1,5 @@
 {
-  "bundle-install": "github.com/paketo-community/bundle-install",
-  "bundler": "github.com/paketo-community/bundler",
-  "mri": "github.com/paketo-community/mri"
+  "bundle-install": "github.com/paketo-buildpacks/bundle-install",
+  "bundler": "github.com/paketo-buildpacks/bundler",
+  "mri": "github.com/paketo-buildpacks/mri"
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Buildpack urls in the `integration.json` file were still pointing to the old buildpack repos in `paketo-community`. This PR updates that.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
