### PR TITLE
Bumps buildpack API to 0.6

### DIFF
--- a/build.go
+++ b/build.go
@@ -48,16 +48,15 @@ func Build(dependencyManager DependencyManager, clock chronos.Clock, logger scri
 		logger.Break()
 
 		return packit.BuildResult{
+			Layers: []packit.Layer{curlLayer},
 			Launch: packit.LaunchMetadata{
 				Processes: []packit.Process{
 					{
 						Type:    "web",
 						Command: command,
+						Default: true,
 					},
 				},
-			},
-			Layers: []packit.Layer{
-				curlLayer,
 			},
 		}, nil
 	}

--- a/build_test.go
+++ b/build_test.go
@@ -3,7 +3,6 @@ package passenger_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,13 +33,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		layersDir, err = ioutil.TempDir("", "layers")
+		layersDir, err = os.MkdirTemp("", "layers")
 		Expect(err).NotTo(HaveOccurred())
 
-		cnbDir, err = ioutil.TempDir("", "cnb")
+		cnbDir, err = os.MkdirTemp("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
 
-		workingDir, err = ioutil.TempDir("", "working-dir")
+		workingDir, err = os.MkdirTemp("", "working-dir")
 		Expect(err).NotTo(HaveOccurred())
 
 		dependencyManager = &fakes.DependencyManager{}
@@ -81,6 +80,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					{
 						Type:    "web",
 						Command: "bundle exec passenger start --port ${PORT:-3000}",
+						Default: true,
 					},
 				},
 			},
@@ -135,7 +135,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		context("when the curl layer cannot be created", func() {
 			it.Before(func() {
-				Expect(ioutil.WriteFile(filepath.Join(layersDir, "curl.toml"), nil, 0000)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(layersDir, "curl.toml"), nil, 0000)).To(Succeed())
 			})
 
 			it("returns an error", func() {

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-api = "0.5"
+api = "0.6"
 
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/passenger"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
All buildpacks that have upgraded to the latest version of `packit` should be able to run with buildpack API 0.6.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
