### PR TITLE
Parse port from passengerfile

### DIFF
--- a/build.go
+++ b/build.go
@@ -61,8 +61,8 @@ func Build(dependencyManager DependencyManager, passengerfileParser Passengerfil
 		}
 
 		port := 3000
-		if passengerfileConfig.Port != 0 {
-			port = passengerfileConfig.Port
+		if passengerfileConfig.Port != nil {
+			port = *passengerfileConfig.Port
 		}
 
 		args := fmt.Sprintf(`bundle exec passenger start --port ${PORT:-%d}`, port)

--- a/build.go
+++ b/build.go
@@ -20,7 +20,7 @@ type DependencyManager interface {
 }
 
 type PassengerfileConfigParser interface {
-	Parse(path string) (Passengerfile, error)
+	ParsePort(path string, defaultPort int) (int, error)
 }
 
 func Build(dependencyManager DependencyManager, passengerfileParser PassengerfileConfigParser, clock chronos.Clock, logger scribe.Emitter) packit.BuildFunc {
@@ -55,14 +55,11 @@ func Build(dependencyManager DependencyManager, passengerfileParser Passengerfil
 		logger.Break()
 
 		passengerfilePath := filepath.Join(context.WorkingDir, "Passengerfile.json")
-		passengerfileConfig, err := passengerfileParser.Parse(passengerfilePath)
+
+		defaultPort := 3000
+		port, err := passengerfileParser.ParsePort(passengerfilePath, defaultPort)
 		if err != nil {
 			return packit.BuildResult{}, err
-		}
-
-		port := 3000
-		if passengerfileConfig.Port != nil {
-			port = *passengerfileConfig.Port
 		}
 
 		args := fmt.Sprintf(`bundle exec passenger start --port ${PORT:-%d}`, port)

--- a/build_test.go
+++ b/build_test.go
@@ -120,7 +120,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the Passengerfile parser returns a config with a port", func() {
 		it.Before(func() {
-			passengerfileParser.ParseCall.Returns.Passengerfile = passenger.Passengerfile{Port: 1234}
+			port := 1234
+			passengerfileParser.ParseCall.Returns.Passengerfile = passenger.Passengerfile{Port: &port}
 
 		})
 

--- a/fakes/passengerfile_parser.go
+++ b/fakes/passengerfile_parser.go
@@ -1,0 +1,33 @@
+package fakes
+
+import (
+	"sync"
+
+	"github.com/paketo-buildpacks/passenger"
+)
+
+type PassengerfileConfigParser struct {
+	ParseCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Path string
+		}
+		Returns struct {
+			Passengerfile passenger.Passengerfile
+			Error         error
+		}
+		Stub func(string) (passenger.Passengerfile, error)
+	}
+}
+
+func (f *PassengerfileConfigParser) Parse(param1 string) (passenger.Passengerfile, error) {
+	f.ParseCall.mutex.Lock()
+	defer f.ParseCall.mutex.Unlock()
+	f.ParseCall.CallCount++
+	f.ParseCall.Receives.Path = param1
+	if f.ParseCall.Stub != nil {
+		return f.ParseCall.Stub(param1)
+	}
+	return f.ParseCall.Returns.Passengerfile, f.ParseCall.Returns.Error
+}

--- a/fakes/passengerfile_parser.go
+++ b/fakes/passengerfile_parser.go
@@ -1,33 +1,31 @@
 package fakes
 
-import (
-	"sync"
-
-	"github.com/paketo-buildpacks/passenger"
-)
+import "sync"
 
 type PassengerfileConfigParser struct {
-	ParseCall struct {
+	ParsePortCall struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			Path string
+			Path        string
+			DefaultPort int
 		}
 		Returns struct {
-			Passengerfile passenger.Passengerfile
-			Error         error
+			Int   int
+			Error error
 		}
-		Stub func(string) (passenger.Passengerfile, error)
+		Stub func(string, int) (int, error)
 	}
 }
 
-func (f *PassengerfileConfigParser) Parse(param1 string) (passenger.Passengerfile, error) {
-	f.ParseCall.mutex.Lock()
-	defer f.ParseCall.mutex.Unlock()
-	f.ParseCall.CallCount++
-	f.ParseCall.Receives.Path = param1
-	if f.ParseCall.Stub != nil {
-		return f.ParseCall.Stub(param1)
+func (f *PassengerfileConfigParser) ParsePort(param1 string, param2 int) (int, error) {
+	f.ParsePortCall.mutex.Lock()
+	defer f.ParsePortCall.mutex.Unlock()
+	f.ParsePortCall.CallCount++
+	f.ParsePortCall.Receives.Path = param1
+	f.ParsePortCall.Receives.DefaultPort = param2
+	if f.ParsePortCall.Stub != nil {
+		return f.ParsePortCall.Stub(param1, param2)
 	}
-	return f.ParseCall.Returns.Passengerfile, f.ParseCall.Returns.Error
+	return f.ParsePortCall.Returns.Int, f.ParsePortCall.Returns.Error
 }

--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitPassenger(t *testing.T) {
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
 	suite("GemfileParser", testGemfileParser)
+	suite("PassengerfileParser", testPassengerfileParser)
 	suite.Run(t)
 }

--- a/passengerfile_parser.go
+++ b/passengerfile_parser.go
@@ -1,0 +1,43 @@
+package passenger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/paketo-buildpacks/packit/v2/fs"
+)
+
+type PassengerfileParser struct{}
+
+func NewPassengerfileParser() PassengerfileParser {
+	return PassengerfileParser{}
+}
+
+type Passengerfile struct {
+	Port int `json:"port"`
+}
+
+func (p PassengerfileParser) Parse(path string) (Passengerfile, error) {
+	exists, err := fs.Exists(path)
+	if err != nil {
+		return Passengerfile{}, fmt.Errorf("failed to determine if Passengerfile exists: %w", err)
+	}
+
+	if !exists {
+		return Passengerfile{}, nil
+	}
+
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return Passengerfile{}, fmt.Errorf("failed to read Passengerfile: %w", err)
+	}
+
+	passengerfile := Passengerfile{}
+	err = json.Unmarshal(content, &passengerfile)
+	if err != nil {
+		return Passengerfile{}, fmt.Errorf("failed to parse Passengerfile: %w", err)
+	}
+
+	return passengerfile, nil
+}

--- a/passengerfile_parser.go
+++ b/passengerfile_parser.go
@@ -18,26 +18,30 @@ type Passengerfile struct {
 	Port *int `json:"port,omitempty"`
 }
 
-func (p PassengerfileParser) Parse(path string) (Passengerfile, error) {
+func (p PassengerfileParser) ParsePort(path string, defaultPort int) (int, error) {
 	exists, err := fs.Exists(path)
 	if err != nil {
-		return Passengerfile{}, fmt.Errorf("failed to determine if Passengerfile exists: %w", err)
+		return 0, fmt.Errorf("failed to determine if Passengerfile exists: %w", err)
 	}
 
 	if !exists {
-		return Passengerfile{}, nil
+		return defaultPort, nil
 	}
 
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		return Passengerfile{}, fmt.Errorf("failed to read Passengerfile: %w", err)
+		return 0, fmt.Errorf("failed to read Passengerfile: %w", err)
 	}
 
 	passengerfile := Passengerfile{}
 	err = json.Unmarshal(content, &passengerfile)
 	if err != nil {
-		return Passengerfile{}, fmt.Errorf("failed to parse Passengerfile: %w", err)
+		return 0, fmt.Errorf("failed to parse Passengerfile: %w", err)
 	}
 
-	return passengerfile, nil
+	if passengerfile.Port == nil {
+		return defaultPort, nil
+	}
+
+	return *passengerfile.Port, nil
 }

--- a/passengerfile_parser.go
+++ b/passengerfile_parser.go
@@ -15,7 +15,7 @@ func NewPassengerfileParser() PassengerfileParser {
 }
 
 type Passengerfile struct {
-	Port int `json:"port"`
+	Port *int `json:"port,omitempty"`
 }
 
 func (p PassengerfileParser) Parse(path string) (Passengerfile, error) {

--- a/passengerfile_parser_test.go
+++ b/passengerfile_parser_test.go
@@ -40,7 +40,8 @@ func testPassengerfileParser(t *testing.T, context spec.G, it spec.S) {
 			passengerfile, err := parser.Parse(path)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(passengerfile).To(Equal(passenger.Passengerfile{Port: 4000}))
+			expectedPort := 4000
+			Expect(passengerfile).To(Equal(passenger.Passengerfile{Port: &expectedPort}))
 		})
 
 		context("when the Passengerfile does not exist", func() {
@@ -65,7 +66,7 @@ func testPassengerfileParser(t *testing.T, context spec.G, it spec.S) {
 				passengerfile, err := parser.Parse(path)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(passengerfile).To(Equal(passenger.Passengerfile{Port: 0}))
+				Expect(passengerfile).To(Equal(passenger.Passengerfile{Port: nil}))
 			})
 		})
 

--- a/passengerfile_parser_test.go
+++ b/passengerfile_parser_test.go
@@ -1,0 +1,124 @@
+package passenger_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/passenger"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testPassengerfileParser(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		path   string
+		parser passenger.PassengerfileParser
+	)
+
+	it.Before(func() {
+		file, err := os.CreateTemp("", "Passengerfile.json")
+		Expect(err).NotTo(HaveOccurred())
+		defer file.Close()
+
+		path = file.Name()
+
+		parser = passenger.NewPassengerfileParser()
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(path)).To(Succeed())
+	})
+
+	context("Parse", func() {
+		it("returns the parsed Passengerfile", func() {
+			Expect(os.WriteFile(path, []byte(`{"port":4000}`), 0644)).To(Succeed())
+
+			passengerfile, err := parser.Parse(path)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(passengerfile).To(Equal(passenger.Passengerfile{Port: 4000}))
+		})
+
+		context("when the Passengerfile does not exist", func() {
+			it.Before(func() {
+				Expect(os.Remove(path)).To(Succeed())
+			})
+
+			it("returns empty Passengerfile struct", func() {
+				passengerfile, err := parser.Parse(path)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(passengerfile).To(Equal(passenger.Passengerfile{}))
+			})
+		})
+
+		context("when the Passengerfile does not contain the port field", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(path, []byte(`{"some-other-field":"some-other-value"}`), 0644)).To(Succeed())
+			})
+
+			it("returns Passengerfile struct with default port", func() {
+				passengerfile, err := parser.Parse(path)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(passengerfile).To(Equal(passenger.Passengerfile{Port: 0}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when determining if the Passengerfile exists fails", func() {
+				var (
+					tempDir string
+				)
+
+				it.Before(func() {
+					var err error
+					tempDir, err = os.MkdirTemp("", "")
+					Expect(err).NotTo(HaveOccurred())
+
+					Expect(os.Chmod(tempDir, 0000)).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.RemoveAll(tempDir)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := parser.Parse(filepath.Join(tempDir, "some-file"))
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(ContainSubstring("failed to determine if Passengerfile exists:")))
+					Expect(err).To(MatchError(ContainSubstring("some-file")))
+				})
+			})
+
+			context("when the Passengerfile cannot be opened", func() {
+				it.Before(func() {
+					Expect(os.Chmod(path, 0000)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := parser.Parse(path)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(ContainSubstring("failed to read Passengerfile:")))
+					Expect(err).To(MatchError(ContainSubstring("permission denied")))
+				})
+			})
+
+			context("when the Passengerfile is malformed", func() {
+				it.Before(func() {
+					Expect(os.WriteFile(path, []byte(`{"port":"not-an-integer"}`), 0644)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := parser.Parse(path)
+					Expect(err).To(HaveOccurred())
+					Expect(err).To(MatchError(ContainSubstring("failed to parse Passengerfile:")))
+				})
+			})
+		})
+	})
+}

--- a/run/main.go
+++ b/run/main.go
@@ -17,6 +17,7 @@ func main() {
 		passenger.Detect(passenger.NewGemfileParser()),
 		passenger.Build(
 			postal.NewService(cargo.NewTransport()),
+			passenger.NewPassengerfileParser(),
 			chronos.DefaultClock,
 			logger,
 		),


### PR DESCRIPTION
## Summary

This PR adds support for using the port provided via the `Passengerfile.json` if the file exists and the port is present.

It preserves the existing behavior of allowing the port to be overridden at runtime via the `$PORT` environment variable.

The old priority ordering was:

1. Runtime `$PORT` environment variable
2. Default value of `3000` hard-coded into the buildpack

The new priority ordering becomes:

1. Runtime `$PORT` environment variable
2. Port from `Passengerfile.json`, if present
3. Default value of `3000` hard-coded into the buildpack

Closes #6

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
