### PR TITLE
Run dependency tests on bionic and jammy

### DIFF
--- a/dependency/test/README.md
+++ b/dependency/test/README.md
@@ -18,5 +18,5 @@ $ ./test.sh \
   --expectedVersion 999.999.999
 tarballPath=/tmp/output_dir/curl_7.85.0_linux_bionic_f0e0bef7.tgz
 expectedVersion=999.999.999
-Version 3.10.7 does not match expected version 999.999.999
+Version 7.85.0 does not match expected version 999.999.999
 ```

--- a/dependency/test/README.md
+++ b/dependency/test/README.md
@@ -1,31 +1,22 @@
 To test locally:
 
 ```shell
-# assume $output_dir is the output from the compilation step, with a tarball and a checksum in it
-
-docker run -it \
-  --volume $output_dir:/tmp/output_dir \
-  --volume $PWD:/tmp/test \
-  ubuntu:jammy \
-  bash
-
-# Now on the container
-
-$ apt-get update && apt-get install ca-certificates -y
+# Assume $output_dir is the output from the compilation step, with a tarball and a checksum in it.
+# Note that the wildcard is not quoted, to allow globbing
 
 # Passing
-$ /tmp/test/test.sh \
-  --tarballPath /tmp/output_dir/curl_7.85.0_linux_jammy_c3a27edf.tgz \
+$ ./test.sh \
+  --tarballPath ${output_dir}/*.tgz \
   --expectedVersion 7.85.0
-tarballPath=/tmp/output_dir/curl_7.85.0_linux_jammy_c3a27edf.tgz
+tarballPath=/tmp/output_dir/curl_7.85.0_linux_bionic_f0e0bef7.tgz
 expectedVersion=7.85.0
 All tests passed!
 
 # Failing
-$ /tmp/test/test.sh \
-  --tarballPath /tmp/output_dir/curl_7.85.0_linux_jammy_c3a27edf.tgz \
-  --expectedVersion 7.84.0
-tarballPath=/tmp/output_dir/curl_7.85.0_linux_jammy_c3a27edf.tgz
-expectedVersion=7.84.0
-Version 7.85.0 does not match expected version 7.84.0
+$ ./test.sh \
+  --tarballPath ${output_dir}/*.tgz \
+  --expectedVersion 999.999.999
+tarballPath=/tmp/output_dir/curl_7.85.0_linux_bionic_f0e0bef7.tgz
+expectedVersion=999.999.999
+Version 3.10.7 does not match expected version 999.999.999
 ```

--- a/dependency/test/bionic.Dockerfile
+++ b/dependency/test/bionic.Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get -y install openssl ca-certificates
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/dependency/test/entrypoint.sh
+++ b/dependency/test/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -euo pipefail
+shopt -s inherit_errexit
+
+extract_tarball() {
+  rm -rf curl
+  mkdir curl
+  tar --extract \
+    --file "$1" \
+    --directory curl
+}
+
+set_ld_library_path() {
+  export LD_LIBRARY_PATH="$PWD/curl/lib:${LD_LIBRARY_PATH:-}"
+}
+
+check_version() {
+  expected_version=$1
+  actual_version="$(./curl/bin/curl -V | head -n1 | awk '{ print $2 }')"
+  if [[ "${actual_version}" != "${expected_version}" ]]; then
+    echo "Version ${actual_version} does not match expected version ${expected_version}"
+    exit 1
+  fi
+}
+
+check_server() {
+  output="$(mktemp)"
+  if ! ./curl/bin/curl -fsS https://example.org > "${output}"; then
+    cat "${output}"
+    exit 1
+  fi
+}
+
+main() {
+  local tarballPath expectedVersion
+  tarballPath=""
+  expectedVersion=""
+
+  while [ "${#}" != 0 ]; do
+    case "${1}" in
+      --tarballPath)
+        tarballPath="${2}"
+        shift 2
+        ;;
+
+      --expectedVersion)
+        expectedVersion="${2}"
+        shift 2
+        ;;
+
+      "")
+        shift
+        ;;
+
+      *)
+        echo "unknown argument \"${1}\""
+        exit 1
+    esac
+  done
+
+  if [[ "${tarballPath}" == "" ]]; then
+    echo "--tarballPath is required"
+    exit 1
+  fi
+
+  if [[ "${expectedVersion}" == "" ]]; then
+    echo "--expectedVersion is required"
+    exit 1
+  fi
+
+  echo "tarballPath=${tarballPath}"
+  echo "expectedVersion=${expectedVersion}"
+
+  extract_tarball "${tarballPath}"
+  set_ld_library_path
+  check_version "${expectedVersion}"
+  check_server
+
+  echo "All tests passed!"
+}
+
+main "$@"

--- a/dependency/test/jammy.Dockerfile
+++ b/dependency/test/jammy.Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:jammy
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && \
+  apt-get -y install openssl ca-certificates
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
Run the dependency tests on a docker image (either bionic or jammy) so that the dynamic SSL linking can be verified.

## Use Cases
Note that this is not exactly running the tests on the minimal stack image as per https://github.com/paketo-buildpacks/github-config/issues/596#issuecomment-1297466914, but it's a good start. We'll probably introduce some workflow changes in this area soon, so I don't think it's necessary to wait for a more full solution.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
